### PR TITLE
[PR] Implement post-process of PoseNet model

### DIFF
--- a/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
+++ b/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
@@ -19,13 +19,14 @@
 		7105C93A241E7624001A4325 /* posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 7105C939241E7624001A4325 /* posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite */; };
 		7105C93C241E8CE3001A4325 /* CVPixelBufferExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7105C93B241E8CE3001A4325 /* CVPixelBufferExtension.swift */; };
 		7105C93E241E90C2001A4325 /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7105C93D241E90C2001A4325 /* DataExtension.swift */; };
+		7138DCCF242142FE0048E1D2 /* TFLiteFlatArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */; };
 		E0C93A920161DEF82C2B75E0 /* Pods_PoseEstimation_TFLiteSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D99304E5824CB3ABF8752B4 /* Pods_PoseEstimation_TFLiteSwift.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		2CB3B8CB51A6B2D98D208272 /* Pods-PoseEstimation-TFLiteSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PoseEstimation-TFLiteSwift.debug.xcconfig"; path = "Target Support Files/Pods-PoseEstimation-TFLiteSwift/Pods-PoseEstimation-TFLiteSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		5D99304E5824CB3ABF8752B4 /* Pods_PoseEstimation_TFLiteSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PoseEstimation_TFLiteSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7105C912241CE9B5001A4325 /* PoseEstimation-TFLiteSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PoseEstimation-TFLiteSwift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7105C912241CE9B5001A4325 /* Pose-TFLiteSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pose-TFLiteSwift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7105C915241CE9B5001A4325 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7105C919241CE9B6001A4325 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		7105C91C241CE9B6001A4325 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -39,6 +40,7 @@
 		7105C939241E7624001A4325 /* posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite; sourceTree = "<group>"; };
 		7105C93B241E8CE3001A4325 /* CVPixelBufferExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVPixelBufferExtension.swift; sourceTree = "<group>"; };
 		7105C93D241E90C2001A4325 /* DataExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
+		7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteFlatArray.swift; sourceTree = "<group>"; };
 		8C8112449130BEE4072F1385 /* Pods-PoseEstimation-TFLiteSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; path = "Target Support Files/Pods-PoseEstimation-TFLiteSwift/Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -67,7 +69,7 @@
 		7105C913241CE9B5001A4325 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7105C912241CE9B5001A4325 /* PoseEstimation-TFLiteSwift.app */,
+				7105C912241CE9B5001A4325 /* Pose-TFLiteSwift.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -112,6 +114,7 @@
 				7105C92E241D0235001A4325 /* PoseEstimator.swift */,
 				7105C934241D0821001A4325 /* PoseNetPoseEstimator.swift */,
 				7105C932241D0651001A4325 /* TFLiteImageInterpreter.swift */,
+				7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */,
 			);
 			name = MLModel;
 			sourceTree = "<group>";
@@ -159,7 +162,7 @@
 			);
 			name = "PoseEstimation-TFLiteSwift";
 			productName = "PoseEstimation-TFLiteSwift";
-			productReference = 7105C912241CE9B5001A4325 /* PoseEstimation-TFLiteSwift.app */;
+			productReference = 7105C912241CE9B5001A4325 /* Pose-TFLiteSwift.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -244,6 +247,7 @@
 				7105C91A241CE9B6001A4325 /* ViewController.swift in Sources */,
 				7105C916241CE9B5001A4325 /* AppDelegate.swift in Sources */,
 				7105C92F241D0235001A4325 /* PoseEstimator.swift in Sources */,
+				7138DCCF242142FE0048E1D2 /* TFLiteFlatArray.swift in Sources */,
 				7105C93E241E90C2001A4325 /* DataExtension.swift in Sources */,
 				7105C937241D29B8001A4325 /* VideoCapture.swift in Sources */,
 				7105C935241D0821001A4325 /* PoseNetPoseEstimator.swift in Sources */,
@@ -400,7 +404,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tucan9389.PoseEstimation-TFLiteSwift";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "Pose-TFLiteSwift";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -420,7 +424,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tucan9389.PoseEstimation-TFLiteSwift";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "Pose-TFLiteSwift";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/PoseEstimation-TFLiteSwift/PoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/PoseEstimator.swift
@@ -8,19 +8,14 @@
 
 import CoreVideo
 
-struct PoseEstimationKeypoint {
+struct Keypoint {
     let position: CGPoint
     let score: CGFloat
 }
 
-struct PoseEstimationHeatmaps {
+struct Keypoints {
     // <#TODO#>
-    let keypoints: [PoseEstimationKeypoint]
-    
-    init(tfliteResult: TFLiteResult) {
-        // <#TODO#>
-        keypoints = []
-    }
+    var keypoints: [Keypoint] = []
 }
 
 enum PoseEstimationError: Error {
@@ -29,5 +24,5 @@ enum PoseEstimationError: Error {
 }
 
 protocol PoseEstimator {
-    func inference(with pixelBuffer: CVPixelBuffer) -> Result<PoseEstimationHeatmaps, PoseEstimationError>
+    func inference(with pixelBuffer: CVPixelBuffer) -> Result<Keypoints, PoseEstimationError>
 }

--- a/PoseEstimation-TFLiteSwift/PoseNetPoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/PoseNetPoseEstimator.swift
@@ -9,30 +9,98 @@
 import CoreVideo
 
 class PoseNetPoseEstimator: PoseEstimator {
+    typealias PoseNetResult = Result<Keypoints, PoseEstimationError>
+    
     lazy var imageInterpreter: TFLiteImageInterpreter = {
         let options = TFLiteImageInterpreter.Options(
             modelName: "posenet_mobilenet_v1_100_257x257_multi_kpt_stripped",
-            inputWidth: 257,
-            inputHeight: 257,
+            inputWidth: Input.width,
+            inputHeight: Input.height,
+            isGrayScale: Input.isGrayScale,
             isNormalized: true
         )
         let imageInterpreter = TFLiteImageInterpreter(options: options)
         return imageInterpreter
     }()
     
-    func inference(with pixelBuffer: CVPixelBuffer) -> Result<PoseEstimationHeatmaps, PoseEstimationError> {
+    func inference(with pixelBuffer: CVPixelBuffer) -> PoseNetResult {
         // preprocss
-        guard let inputData = imageInterpreter.preprocessMiddleSquareArea(with: pixelBuffer) else { return .failure(.failToCreateInputData) }
+        guard let inputData = imageInterpreter.preprocessMiddleSquareArea(with: pixelBuffer)
+            else { return .failure(.failToCreateInputData) }
         // inference
-        guard let tfliteResult = imageInterpreter.inference(with: inputData) else { return .failure(.failToInference) }
+        guard let outputs = imageInterpreter.inference(with: inputData)
+            else { return .failure(.failToInference) }
         // postprocess
-        let result = postprocess(with: tfliteResult)
+        let result = postprocess(with: outputs)
         
         return result
     }
     
-    private func postprocess(with tfliteResult: TFLiteResult) -> Result<PoseEstimationHeatmaps, PoseEstimationError> {
-        // <#TODO#>
-        return .success(PoseEstimationHeatmaps(tfliteResult: tfliteResult))
+    private func postprocess(with outputs: [TFLiteFlatArray<Float32>]) -> PoseNetResult {
+        return .success(Keypoints(outputs: outputs))
+    }
+}
+
+private extension PoseNetPoseEstimator {
+    struct Input {
+        static let width = 257
+        static let height = 257
+        static let isGrayScale = false
+    }
+    struct Output {
+        struct Heatmap {
+            static let width = 9
+            static let height = 9
+            static let count = 17
+        }
+        struct Offset {
+            static let width = 9
+            static let height = 9
+            static let count = 34
+        }
+    }
+}
+
+private extension Keypoints {
+    init(outputs: [TFLiteFlatArray<Float32>]) {
+        let heatmaps = outputs[0]
+        let offsets = outputs[1]
+        
+        // get (col, row)s from heatmaps
+        let keypointIndexInfos: [(row: Int, col: Int, val: Float32)] = (0..<PoseNetPoseEstimator.Output.Heatmap.count).map { heatmapIndex in
+            var maxInfo = (row: 0, col: 0, val: heatmaps[0, 0, 0, heatmapIndex])
+            for row in 0..<PoseNetPoseEstimator.Output.Heatmap.height {
+                for col in 0..<PoseNetPoseEstimator.Output.Heatmap.width {
+                    if heatmaps[0, row, col, heatmapIndex] > maxInfo.val {
+                        maxInfo = (row: row, col: col, val: heatmaps[0, row, col, heatmapIndex])
+                    }
+                }
+            }
+            return maxInfo
+        }
+        
+        // get points from (col, row)s and offsets
+        let keypointInfos: [(point: CGPoint, score: CGFloat)] = keypointIndexInfos.enumerated().map { (index, keypointInfo) in
+            // (0.0, 0.0)~(1.0, 1.0)
+            let xNaive = (CGFloat(keypointInfo.col) + 0.5) / CGFloat(PoseNetPoseEstimator.Output.Heatmap.width)
+            let yNaive = (CGFloat(keypointInfo.row) + 0.5) / CGFloat(PoseNetPoseEstimator.Output.Heatmap.height)
+            
+            // (0.0, 0.0)~(Input.width, Input.height)
+            let xOffset = offsets[0, keypointInfo.row, keypointInfo.col, index + PoseNetPoseEstimator.Output.Heatmap.count]
+            let yOffset = offsets[0, keypointInfo.row, keypointInfo.col, index]
+            
+            // (0.0, 0.0)~(Input.width, Input.height)
+            let xScaledInput = xNaive * CGFloat(PoseNetPoseEstimator.Input.width) + CGFloat(xOffset)
+            let yScaledInput = yNaive * CGFloat(PoseNetPoseEstimator.Input.height) + CGFloat(yOffset)
+            
+            // (0.0, 0.0)~(1.0, 1.0)
+            let x = xScaledInput / CGFloat(PoseNetPoseEstimator.Input.width)
+            let y = yScaledInput / CGFloat(PoseNetPoseEstimator.Input.height)
+            let score = CGFloat(keypointInfo.val)
+            
+            return (point: CGPoint(x: x, y: y), score: score)
+        }
+        
+        keypoints = keypointInfos.map { keypointInfo in Keypoint(position: keypointInfo.point, score: keypointInfo.score) }
     }
 }

--- a/PoseEstimation-TFLiteSwift/TFLiteFlatArray.swift
+++ b/PoseEstimation-TFLiteSwift/TFLiteFlatArray.swift
@@ -1,0 +1,45 @@
+//
+//  TFLiteFlatArray.swift
+//  PoseEstimation-TFLiteSwift
+//
+//  Created by Doyoung Gwak on 2020/03/18.
+//  Copyright © 2020 Doyoung Gwak. All rights reserved.
+//
+
+import TensorFlowLite
+
+// MARK: - Wrappers
+/// Struct for handling multidimension `Data` in flat `Array`.
+struct TFLiteFlatArray<Element: AdditiveArithmetic> {
+    private var array: [Element]
+    var dimensions: [Int]
+    
+    init(tensor: Tensor) {
+        dimensions = tensor.shape.dimensions
+        array = tensor.data.toArray(type: Element.self)
+    }
+    
+    private func flatIndex(_ index: [Int]) -> Int {
+        guard index.count == dimensions.count else {
+            fatalError("Invalid index: got \(index.count) index(es) for \(dimensions.count) index(es).")
+        }
+        
+        var result = 0
+        for i in 0..<dimensions.count {
+            guard dimensions[i] > index[i] else {
+                fatalError("Invalid index: \(index[i]) is bigger than \(dimensions[i])")
+            }
+            result = dimensions[i] * result + index[i]
+        }
+        return result
+    }
+    
+    subscript(_ index: Int...) -> Element {
+        get {
+            return array[flatIndex(index)]
+        }
+        set(newValue) {
+            array[flatIndex(index)] = newValue
+        }
+    }
+}

--- a/PoseEstimation-TFLiteSwift/TFLiteImageInterpreter.swift
+++ b/PoseEstimation-TFLiteSwift/TFLiteImageInterpreter.swift
@@ -9,7 +9,7 @@
 import TensorFlowLite
 
 struct TFLiteResult {
-    // <#TODO#>
+    let outputTensors: [Tensor]
 }
 
 class TFLiteImageInterpreter {
@@ -110,7 +110,7 @@ class TFLiteImageInterpreter {
         return inputData
     }
     
-    func inference(with inputData: Data) -> TFLiteResult? {
+    func inference(with inputData: Data) -> [TFLiteFlatArray<Float32>]? {
         // Copy the initialized `Data` to the input `Tensor`.
         do {
             // Copy input into interpreter's 0th `Tensor`.
@@ -123,10 +123,12 @@ class TFLiteImageInterpreter {
             for (index) in 0..<outputTensors.count {
                 outputTensors[index] = try interpreter.output(at: index)
             }
-        } catch let error {
-            fatalError("Failed to invoke the interpreter with error:" + error.localizedDescription)
+        } catch /*let error*/ {
+            // fatalError("Failed to invoke the interpreter with error:" + error.localizedDescription)
+            return nil
         }
-        return nil
+        
+        return outputTensors.map { TFLiteFlatArray(tensor: $0) }
     }
 }
 
@@ -138,18 +140,18 @@ extension TFLiteImageInterpreter {
         let isQuantized: Bool
         let inputWidth: Int
         let inputHeight: Int
-        let isRGB: Bool
-        var inputChannel: Int { return isRGB ? 3 : 1 }
+        let isGrayScale: Bool
+        var inputChannel: Int { return isGrayScale ? 1 : 3 }
         let isNormalized: Bool // true: 0.0~1.0, false: 0.0~255.0
         
-        init(modelName: String, threadCount: Int = 1, accelerator: Accelerator = .metal, isQuantized: Bool = false, inputWidth: Int, inputHeight: Int, isRGB: Bool = true, isNormalized: Bool = false) {
+        init(modelName: String, threadCount: Int = 1, accelerator: Accelerator = .metal, isQuantized: Bool = false, inputWidth: Int, inputHeight: Int, isGrayScale: Bool = false, isNormalized: Bool = false) {
             self.modelName = modelName
             self.threadCount = threadCount
             self.accelerator = accelerator
             self.isQuantized = isQuantized
             self.inputWidth = inputWidth
             self.inputHeight = inputHeight
-            self.isRGB = isRGB
+            self.isGrayScale = isGrayScale
             self.isNormalized = isNormalized
         }
     }

--- a/PoseEstimation-TFLiteSwift/ViewController.swift
+++ b/PoseEstimation-TFLiteSwift/ViewController.swift
@@ -76,7 +76,7 @@ extension ViewController: VideoCaptureDelegate {
     func videoCapture(_ capture: VideoCapture, didCaptureVideoFrame pixelBuffer: CVPixelBuffer, timestamp: CMTime) {
         // the captured image from camera is contained on pixelBuffer
         
-        let result = poseEstimator.inference(with: pixelBuffer)
+        let result: Result<Keypoints, PoseEstimationError> = poseEstimator.inference(with: pixelBuffer)
         print(result)
     }
 }


### PR DESCRIPTION
## PR Points

- Implement post-process of PoseNet model in 
- Rename app name to Pose-TFLiteSwift(before: PoseEstimation-TFLiteSwift)

## Post-process Logic

> There are 4 output layers. But in this PR only use `0`th and `1`st outputs.

step | action | dim | dim-description |
---: | --- | :---: | :---:
1 | Get naive index points from `outputs[0]` | `0,0`-`9,9` | heatmap size
2 | Get offsets from `outputs[1]` | `0,0`-`257,257` | input size
3 | Normalize index points | `0.0,0.0`-`1.0,1.0` | -
4 | Scale normalized points up to input size | `0.0,0.0`-`257.0,257.0` | input size
5 | Add offsets to scaled points | `0.0,0.0`-`257.0,257.0` | input size
6 | Normalize the points | `0.0,0.0`-`1.0,1.0` | -