### PR TITLE
Support to inference on still image imported from device's photo album

### DIFF
--- a/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
+++ b/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		7105C93E241E90C2001A4325 /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7105C93D241E90C2001A4325 /* DataExtension.swift */; };
 		712A7FC12424BDD800B043F9 /* StillImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712A7FC02424BDD800B043F9 /* StillImageViewController.swift */; };
 		712A7FC4242504EB00B043F9 /* PoseKeypointsDrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712A7FC3242504EB00B043F9 /* PoseKeypointsDrawingView.swift */; };
+		712A7FC62425FD7200B043F9 /* UIImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712A7FC52425FD7200B043F9 /* UIImageExtension.swift */; };
 		7138DCCF242142FE0048E1D2 /* TFLiteFlatArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */; };
 		E0C93A920161DEF82C2B75E0 /* Pods_PoseEstimation_TFLiteSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D99304E5824CB3ABF8752B4 /* Pods_PoseEstimation_TFLiteSwift.framework */; };
 /* End PBXBuildFile section */
@@ -44,6 +45,7 @@
 		7105C93D241E90C2001A4325 /* DataExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
 		712A7FC02424BDD800B043F9 /* StillImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StillImageViewController.swift; sourceTree = "<group>"; };
 		712A7FC3242504EB00B043F9 /* PoseKeypointsDrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseKeypointsDrawingView.swift; sourceTree = "<group>"; };
+		712A7FC52425FD7200B043F9 /* UIImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtension.swift; sourceTree = "<group>"; };
 		7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteFlatArray.swift; sourceTree = "<group>"; };
 		8C8112449130BEE4072F1385 /* Pods-PoseEstimation-TFLiteSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; path = "Target Support Files/Pods-PoseEstimation-TFLiteSwift/Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -108,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				7105C93B241E8CE3001A4325 /* CVPixelBufferExtension.swift */,
+				712A7FC52425FD7200B043F9 /* UIImageExtension.swift */,
 				7105C93D241E90C2001A4325 /* DataExtension.swift */,
 			);
 			name = Extension;
@@ -267,6 +270,7 @@
 				712A7FC12424BDD800B043F9 /* StillImageViewController.swift in Sources */,
 				7105C937241D29B8001A4325 /* VideoCapture.swift in Sources */,
 				7105C935241D0821001A4325 /* PoseNetPoseEstimator.swift in Sources */,
+				712A7FC62425FD7200B043F9 /* UIImageExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PoseEstimation-TFLiteSwift/Base.lproj/Main.storyboard
+++ b/PoseEstimation-TFLiteSwift/Base.lproj/Main.storyboard
@@ -60,19 +60,29 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Gj5-n8-rgW">
-                                <rect key="frame" x="0.0" y="172" width="414" height="552"/>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Gj5-n8-rgW">
+                                <rect key="frame" x="0.0" y="241" width="414" height="414"/>
                                 <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="Gj5-n8-rgW" secondAttribute="height" multiplier="3:4" id="rQk-Sl-Ehw"/>
+                                    <constraint firstAttribute="width" secondItem="Gj5-n8-rgW" secondAttribute="height" multiplier="1:1" id="rQk-Sl-Ehw"/>
                                 </constraints>
                             </imageView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SKB-f7-Cxs" customClass="PoseKeypointsDrawingView" customModule="Pose_TFLiteSwift" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="241" width="414" height="414"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="SKB-f7-Cxs" secondAttribute="height" multiplier="1:1" id="HEz-NP-xdz"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="Gj5-n8-rgW" firstAttribute="width" secondItem="4rl-xp-TwG" secondAttribute="width" id="129-eU-z3Y"/>
                             <constraint firstItem="Gj5-n8-rgW" firstAttribute="centerY" secondItem="4rl-xp-TwG" secondAttribute="centerY" id="8xX-2l-f6r"/>
+                            <constraint firstItem="SKB-f7-Cxs" firstAttribute="width" secondItem="Gj5-n8-rgW" secondAttribute="width" id="CXj-uJ-KTe"/>
                             <constraint firstItem="Gj5-n8-rgW" firstAttribute="centerX" secondItem="4rl-xp-TwG" secondAttribute="centerX" id="HNf-vb-cJt"/>
+                            <constraint firstItem="SKB-f7-Cxs" firstAttribute="centerY" secondItem="Gj5-n8-rgW" secondAttribute="centerY" id="MVE-mU-Qhm"/>
+                            <constraint firstItem="SKB-f7-Cxs" firstAttribute="centerX" secondItem="Gj5-n8-rgW" secondAttribute="centerX" id="XPU-Gh-tKE"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Jv1-3Q-T9Y"/>
                     </view>
@@ -85,6 +95,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="imageView" destination="Gj5-n8-rgW" id="t39-PT-2kG"/>
+                        <outlet property="overlayView" destination="SKB-f7-Cxs" id="Pn0-pd-2Yo"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="kzl-Ry-BAi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/PoseEstimation-TFLiteSwift/CVPixelBufferExtension.swift
+++ b/PoseEstimation-TFLiteSwift/CVPixelBufferExtension.swift
@@ -24,14 +24,6 @@ extension CVPixelBuffer {
     /// - Returns: The cropped and resized image of itself.
     func resize(from source: CGRect, to size: CGSize) -> CVPixelBuffer? {
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: self.size)
-        guard rect.size.width / rect.size.height - source.size.width / source.size.height < 1e-5
-            else {
-                os_log(
-                    "Resizing Error: source image ratio and destination image ratio is different",
-                    type: .error)
-                return nil
-        }
-        
         let inputImageRowBytes = CVPixelBufferGetBytesPerRow(self)
         let imageChannels = 4
         

--- a/PoseEstimation-TFLiteSwift/LiveImageViewController.swift
+++ b/PoseEstimation-TFLiteSwift/LiveImageViewController.swift
@@ -89,13 +89,18 @@ class LiveImageViewController: UIViewController {
 // MARK: - VideoCaptureDelegate
 extension LiveImageViewController: VideoCaptureDelegate {
     func videoCapture(_ capture: VideoCapture, didCaptureVideoFrame pixelBuffer: CVPixelBuffer, timestamp: CMTime) {
-        
+        inference(with: pixelBuffer)
+    }
+}
+
+extension LiveImageViewController {
+    func inference(with pixelBuffer: CVPixelBuffer) {
         let scalingRatio = pixelBuffer.size.width / overlayViewRelativeRect.width
         let targetAreaRect = overlayViewRelativeRect.scaled(to: scalingRatio)
-        let result: Result<PoseEstimationOutput, PoseEstimationError> = poseEstimator.inference(with: pixelBuffer, on: targetAreaRect)
+        let input: PoseEstimationInput = .pixelBuffer(pixelBuffer: pixelBuffer, cropArea: .customAspectFill(rect: targetAreaRect))
+        let result: Result<PoseEstimationOutput, PoseEstimationError> = poseEstimator.inference(with: input)
         
         DispatchQueue.main.async {
-            print(result)
             switch (result) {
             case .success(let output):
                 self.overlayView?.result = output

--- a/PoseEstimation-TFLiteSwift/PoseNetPoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/PoseNetPoseEstimator.swift
@@ -23,14 +23,9 @@ class PoseNetPoseEstimator: PoseEstimator {
         return imageInterpreter
     }()
     
-    func inference(with pixelBuffer: CVPixelBuffer) -> PoseNetResult {
-        return inference(with: pixelBuffer, on: nil)
-    }
-    
-    func inference(with pixelBuffer: CVPixelBuffer, on targetRect: CGRect?) -> PoseNetResult {
+    func inference(with input: PoseEstimationInput) -> PoseNetResult {
         // preprocss
-        let targetRect = targetRect ?? CGRect(origin: .zero, size: pixelBuffer.size)
-        guard let inputData = imageInterpreter.preprocess(with: pixelBuffer, from: targetRect)
+        guard let inputData = imageInterpreter.preprocess(with: input)
             else { return .failure(.failToCreateInputData) }
         // inference
         guard let outputs = imageInterpreter.inference(with: inputData)

--- a/PoseEstimation-TFLiteSwift/TFLiteImageInterpreter.swift
+++ b/PoseEstimation-TFLiteSwift/TFLiteImageInterpreter.swift
@@ -90,6 +90,22 @@ class TFLiteImageInterpreter {
         return preprocess(with: pixelBuffer, from: targetSquare)
     }
     
+    func preprocess(with input: PoseEstimationInput) -> Data? {
+        let modelInputSize = CGSize(width: options.inputWidth, height: options.inputHeight)
+        guard let thumbnail = input.croppedPixelBuffer(with: modelInputSize) else { return nil }
+        
+        // Remove the alpha component from the image buffer to get the initialized `Data`.
+        let byteCount = 1 * options.inputHeight * options.inputWidth * options.inputChannel
+        guard let inputData = thumbnail.rgbData(byteCount: byteCount,
+                                                isNormalized: options.isNormalized,
+                                                isModelQuantized: options.isQuantized) else {
+            print("Failed to convert the image buffer to RGB data.")
+            return nil
+        }
+        
+        return inputData
+    }
+    
     func preprocess(with pixelBuffer: CVPixelBuffer, from targetSquare: CGRect) -> Data? {
         let sourcePixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
         assert(sourcePixelFormat == kCVPixelFormatType_32BGRA)

--- a/PoseEstimation-TFLiteSwift/UIImageExtension.swift
+++ b/PoseEstimation-TFLiteSwift/UIImageExtension.swift
@@ -1,0 +1,59 @@
+//
+//  UIImageExtension.swift
+//  PoseEstimation-TFLiteSwift
+//
+//  Created by Doyoung Gwak on 2020/03/21.
+//  Copyright © 2020 Doyoung Gwak. All rights reserved.
+//
+
+import UIKit
+
+extension UIImage {
+    func pixelBufferFromImage() -> CVPixelBuffer {
+        let ciimage = CIImage(image: self)
+        //let cgimage = convertCIImageToCGImage(inputImage: ciimage!)
+        let tmpcontext = CIContext(options: nil)
+        let cgimage =  tmpcontext.createCGImage(ciimage!, from: ciimage!.extent)
+        
+        let cfnumPointer = UnsafeMutablePointer<UnsafeRawPointer>.allocate(capacity: 1)
+        let cfnum = CFNumberCreate(kCFAllocatorDefault, .intType, cfnumPointer)
+        let keys: [CFString] = [kCVPixelBufferCGImageCompatibilityKey, kCVPixelBufferCGBitmapContextCompatibilityKey, kCVPixelBufferBytesPerRowAlignmentKey]
+        let values: [CFTypeRef] = [kCFBooleanTrue, kCFBooleanTrue, cfnum!]
+        let keysPointer = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: 1)
+        let valuesPointer =  UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: 1)
+        keysPointer.initialize(to: keys)
+        valuesPointer.initialize(to: values)
+        
+        let options = CFDictionaryCreate(kCFAllocatorDefault, keysPointer, valuesPointer, keys.count, nil, nil)
+        
+        let width = cgimage!.width
+        let height = cgimage!.height
+        
+        var pxbuffer: CVPixelBuffer?
+        // if pxbuffer = nil, you will get status = -6661
+        _ = CVPixelBufferCreate(kCFAllocatorDefault, width, height,
+                                kCVPixelFormatType_32BGRA, options, &pxbuffer)
+        _ = CVPixelBufferLockBaseAddress(pxbuffer!, CVPixelBufferLockFlags(rawValue: 0));
+        
+        let bufferAddress = CVPixelBufferGetBaseAddress(pxbuffer!);
+        
+        
+        let rgbColorSpace = CGColorSpaceCreateDeviceRGB();
+        let bytesperrow = CVPixelBufferGetBytesPerRow(pxbuffer!)
+        let context = CGContext(data: bufferAddress,
+                                width: width,
+                                height: height,
+                                bitsPerComponent: 8,
+                                bytesPerRow: bytesperrow,
+                                space: rgbColorSpace,
+                                bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue);
+        context?.concatenate(CGAffineTransform(rotationAngle: 0))
+        // context?.concatenate(__CGAffineTransformMake( 1, 0, 0, -1, 0, CGFloat(height) )) //Flip Vertical
+        //        context?.concatenate(__CGAffineTransformMake( -1.0, 0.0, 0.0, 1.0, CGFloat(width), 0.0)) //Flip Horizontal
+        
+        
+        context?.draw(cgimage!, in: CGRect(x:0, y:0, width:CGFloat(width), height:CGFloat(height)));
+        _ = CVPixelBufferUnlockBaseAddress(pxbuffer!, CVPixelBufferLockFlags(rawValue: 0));
+        return pxbuffer!;
+    }
+}


### PR DESCRIPTION
## Related Issue 

#13 

## PR Points

- Implement to inference for still image
- Create `PoseEstimationInput` structure
- Support `UIImage` as an input image
- Support square crop with `CropArea` enum