### PR TITLE
[PR] Support openpose model (single-pose yet)

### DIFF
--- a/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
+++ b/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		7138DCCF242142FE0048E1D2 /* TFLiteFlatArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */; };
 		71E8D9172438BAC10081DD6E /* openpose_ildoonet.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 71E8D9162438BAC10081DD6E /* openpose_ildoonet.tflite */; };
 		71E8D9192438BAD80081DD6E /* OpenPosePoseEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E8D9182438BAD80081DD6E /* OpenPosePoseEstimator.swift */; };
+		71E8D93B243CC5330081DD6E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 71E8D93A243CC5320081DD6E /* README.md */; };
 		E0C93A920161DEF82C2B75E0 /* Pods_PoseEstimation_TFLiteSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D99304E5824CB3ABF8752B4 /* Pods_PoseEstimation_TFLiteSwift.framework */; };
 /* End PBXBuildFile section */
 
@@ -61,6 +62,7 @@
 		7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteFlatArray.swift; sourceTree = "<group>"; };
 		71E8D9162438BAC10081DD6E /* openpose_ildoonet.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = openpose_ildoonet.tflite; sourceTree = "<group>"; };
 		71E8D9182438BAD80081DD6E /* OpenPosePoseEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPosePoseEstimator.swift; sourceTree = "<group>"; };
+		71E8D93A243CC5320081DD6E /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		8C8112449130BEE4072F1385 /* Pods-PoseEstimation-TFLiteSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; path = "Target Support Files/Pods-PoseEstimation-TFLiteSwift/Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -79,6 +81,7 @@
 		7105C909241CE9B5001A4325 = {
 			isa = PBXGroup;
 			children = (
+				71E8D93A243CC5320081DD6E /* README.md */,
 				7105C914241CE9B5001A4325 /* PoseEstimation-TFLiteSwift */,
 				7105C913241CE9B5001A4325 /* Products */,
 				C0C61619494007101B3B8411 /* Pods */,
@@ -263,6 +266,7 @@
 				712A7FCF2426690A00B043F9 /* pefm_cpm.tflite in Resources */,
 				71E8D9172438BAC10081DD6E /* openpose_ildoonet.tflite in Resources */,
 				7105C91D241CE9B6001A4325 /* Main.storyboard in Resources */,
+				71E8D93B243CC5330081DD6E /* README.md in Resources */,
 				712A7FCD242668FF00B043F9 /* pefm_hourglass_v2.tflite in Resources */,
 				7105C93A241E7624001A4325 /* posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite in Resources */,
 			);

--- a/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
+++ b/PoseEstimation-TFLiteSwift.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		712A7FD12426691B00B043F9 /* PEFMCPMPoseEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712A7FD02426691B00B043F9 /* PEFMCPMPoseEstimator.swift */; };
 		712A7FD324266EC700B043F9 /* pefm_hourglass_v1.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 712A7FD224266EC700B043F9 /* pefm_hourglass_v1.tflite */; };
 		7138DCCF242142FE0048E1D2 /* TFLiteFlatArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */; };
+		71E8D9172438BAC10081DD6E /* openpose_ildoonet.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 71E8D9162438BAC10081DD6E /* openpose_ildoonet.tflite */; };
+		71E8D9192438BAD80081DD6E /* OpenPosePoseEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E8D9182438BAD80081DD6E /* OpenPosePoseEstimator.swift */; };
 		E0C93A920161DEF82C2B75E0 /* Pods_PoseEstimation_TFLiteSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D99304E5824CB3ABF8752B4 /* Pods_PoseEstimation_TFLiteSwift.framework */; };
 /* End PBXBuildFile section */
 
@@ -57,6 +59,8 @@
 		712A7FD02426691B00B043F9 /* PEFMCPMPoseEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PEFMCPMPoseEstimator.swift; sourceTree = "<group>"; };
 		712A7FD224266EC700B043F9 /* pefm_hourglass_v1.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = pefm_hourglass_v1.tflite; sourceTree = "<group>"; };
 		7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteFlatArray.swift; sourceTree = "<group>"; };
+		71E8D9162438BAC10081DD6E /* openpose_ildoonet.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = openpose_ildoonet.tflite; sourceTree = "<group>"; };
+		71E8D9182438BAD80081DD6E /* OpenPosePoseEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPosePoseEstimator.swift; sourceTree = "<group>"; };
 		8C8112449130BEE4072F1385 /* Pods-PoseEstimation-TFLiteSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; path = "Target Support Files/Pods-PoseEstimation-TFLiteSwift/Pods-PoseEstimation-TFLiteSwift.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -134,6 +138,7 @@
 				7138DCCE242142FE0048E1D2 /* TFLiteFlatArray.swift */,
 				712A7FC22424FEC900B043F9 /* PoseNet */,
 				712A7FC7242667A400B043F9 /* PoseEstimationForMobile */,
+				71E8D9152438BA5B0081DD6E /* OpenPose */,
 			);
 			name = MLModel;
 			sourceTree = "<group>";
@@ -165,6 +170,15 @@
 				712A7FC8242667C900B043F9 /* PEFMHourglassPoseEstimator.swift */,
 			);
 			path = PoseEstimationForMobile;
+			sourceTree = "<group>";
+		};
+		71E8D9152438BA5B0081DD6E /* OpenPose */ = {
+			isa = PBXGroup;
+			children = (
+				71E8D9162438BAC10081DD6E /* openpose_ildoonet.tflite */,
+				71E8D9182438BAD80081DD6E /* OpenPosePoseEstimator.swift */,
+			);
+			path = OpenPose;
 			sourceTree = "<group>";
 		};
 		C0C61619494007101B3B8411 /* Pods */ = {
@@ -247,6 +261,7 @@
 				7105C922241CE9B7001A4325 /* LaunchScreen.storyboard in Resources */,
 				7105C91F241CE9B7001A4325 /* Assets.xcassets in Resources */,
 				712A7FCF2426690A00B043F9 /* pefm_cpm.tflite in Resources */,
+				71E8D9172438BAC10081DD6E /* openpose_ildoonet.tflite in Resources */,
 				7105C91D241CE9B6001A4325 /* Main.storyboard in Resources */,
 				712A7FCD242668FF00B043F9 /* pefm_hourglass_v2.tflite in Resources */,
 				7105C93A241E7624001A4325 /* posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite in Resources */,
@@ -292,6 +307,7 @@
 				7105C916241CE9B5001A4325 /* AppDelegate.swift in Sources */,
 				7105C92F241D0235001A4325 /* PoseEstimator.swift in Sources */,
 				712A7FD12426691B00B043F9 /* PEFMCPMPoseEstimator.swift in Sources */,
+				71E8D9192438BAD80081DD6E /* OpenPosePoseEstimator.swift in Sources */,
 				712A7FC4242504EB00B043F9 /* PoseKeypointsDrawingView.swift in Sources */,
 				7138DCCF242142FE0048E1D2 /* TFLiteFlatArray.swift in Sources */,
 				7105C93E241E90C2001A4325 /* DataExtension.swift in Sources */,

--- a/PoseEstimation-TFLiteSwift/LiveImageViewController.swift
+++ b/PoseEstimation-TFLiteSwift/LiveImageViewController.swift
@@ -29,7 +29,7 @@ class LiveImageViewController: UIViewController {
     var videoCapture = VideoCapture()
     
     // MARK: - ML Property
-    let poseEstimator: PoseEstimator = PoseNetPoseEstimator()
+    let poseEstimator: PoseEstimator = OpenPosePoseEstimator()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/PoseEstimation-TFLiteSwift/OpenPose/OpenPosePoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/OpenPose/OpenPosePoseEstimator.swift
@@ -134,7 +134,7 @@ private extension PoseEstimationOutput {
         }
         
         // get points from (col, row)s and offsets
-        let keypointInfos: [(point: CGPoint, score: CGFloat)] = keypointIndexInfos.enumerated().map { (index, keypointInfo) in
+        let keypointInfos: [(point: CGPoint, score: Float)] = keypointIndexInfos.enumerated().map { (index, keypointInfo) in
             return (point: .zero, score: 0)
         }
         

--- a/PoseEstimation-TFLiteSwift/OpenPose/OpenPosePoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/OpenPose/OpenPosePoseEstimator.swift
@@ -1,0 +1,168 @@
+//
+//  OpenPosePoseEstimator.swift
+//  PoseEstimation-TFLiteSwift
+//
+//  Created by Doyoung Gwak on 2020/04/04.
+//  Copyright © 2020 Doyoung Gwak. All rights reserved.
+//
+
+import CoreGraphics
+
+class OpenPosePoseEstimator: PoseEstimator {
+    typealias OpenPoseResult = Result<PoseEstimationOutput, PoseEstimationError>
+    
+    lazy var imageInterpreter: TFLiteImageInterpreter = {
+        let options = TFLiteImageInterpreter.Options(
+            modelName: "posenet_mobilenet_v1_100_257x257_multi_kpt_stripped",
+            inputWidth: Input.width,
+            inputHeight: Input.height,
+            isGrayScale: Input.isGrayScale,
+            isNormalized: Input.isNormalized
+        )
+        let imageInterpreter = TFLiteImageInterpreter(options: options)
+        return imageInterpreter
+    }()
+    
+    func inference(with input: PoseEstimationInput) -> OpenPoseResult {
+        // preprocss
+        guard let inputData = imageInterpreter.preprocess(with: input)
+            else { return .failure(.failToCreateInputData) }
+        // inference
+        guard let outputs = imageInterpreter.inference(with: inputData)
+            else { return .failure(.failToInference) }
+        // postprocess
+        let result = postprocess(with: outputs)
+        
+        return result
+    }
+    
+    private func postprocess(with outputs: [TFLiteFlatArray<Float32>]) -> OpenPoseResult {
+        return .success(PoseEstimationOutput(outputs: outputs))
+    }
+}
+
+private extension OpenPosePoseEstimator {
+    struct Input {
+        static let width = 368
+        static let height = 432
+        static let isGrayScale = false
+        static let isNormalized = true
+    }
+    struct Output {
+        struct ConfidenceMap { // similar to Heatmap
+            static let width = 46
+            static let height = 54
+            static let count = BodyPart.allCases.count // 19
+        }
+        struct AffinityField {
+            static let width = 46
+            static let height = 54
+            static let count = BodyPart.allCases.count * 2 // 38
+        }
+        enum BodyPart: String, CaseIterable {
+            case NOSE = "nose" // 0
+            case NECK = "Neck" // 1
+            case RIGHT_SHOULDER = "RShoulder" // 2
+            case RIGHT_ELBOW = "RElbow" // 3
+            case RIGHT_WRIST = "RWrist" // 4
+            case LEFT_SHOULDER = "LShoulder" // 5
+            case LEFT_ELBOW = "LElbow" // 6
+            case LEFT_WRIST = "LWrist" // 7
+            case RIGHT_HIP = "RHip" // 8
+            case RIGHT_KNEE = "RKnee" // 9
+            case RIGHT_ANKLE = "RAnkle" // 10
+            case LEFT_HIP = "LHip" // 11
+            case LEFT_KNEE = "LKnee" // 12
+            case LEFT_ANKLE = "LAnkle" // 13
+            case RIGHT_EYE = "REye" // 14
+            case LEFT_EYE = "LEye" // 15
+            case RIGHT_EAR = "REar" // 16
+            case LEFT_EAR = "LEar" // 17
+            case BACKGROUND = "Background" // 18
+
+            // (1, 2), (1, 5), (2, 3), (3, 4), (5, 6), (6, 7), (1, 8), (8, 9), (9, 10), (1, 11),
+            // (11, 12), (12, 13), (1, 0), (0, 14), (14, 16), (0, 15), (15, 17), (2, 16), (5, 17)
+            static let lines = [
+                (from: BodyPart.NECK, to: BodyPart.RIGHT_SHOULDER),
+                (from: BodyPart.NECK, to: BodyPart.LEFT_SHOULDER),
+                (from: BodyPart.RIGHT_SHOULDER, to: BodyPart.RIGHT_ELBOW),
+                (from: BodyPart.RIGHT_ELBOW, to: BodyPart.RIGHT_WRIST),
+                (from: BodyPart.LEFT_SHOULDER, to: BodyPart.LEFT_ELBOW),
+                (from: BodyPart.LEFT_ELBOW, to: BodyPart.LEFT_WRIST),
+                (from: BodyPart.NECK, to: BodyPart.RIGHT_HIP),
+                (from: BodyPart.RIGHT_HIP, to: BodyPart.RIGHT_KNEE),
+                (from: BodyPart.RIGHT_KNEE, to: BodyPart.RIGHT_ANKLE),
+                (from: BodyPart.NECK, to: BodyPart.LEFT_HIP),
+                
+                (from: BodyPart.LEFT_HIP, to: BodyPart.LEFT_KNEE),
+                (from: BodyPart.LEFT_KNEE, to: BodyPart.LEFT_ANKLE),
+                (from: BodyPart.NECK, to: BodyPart.NOSE),
+                (from: BodyPart.NOSE, to: BodyPart.RIGHT_EYE),
+                (from: BodyPart.RIGHT_EYE, to: BodyPart.RIGHT_EAR),
+                (from: BodyPart.NOSE, to: BodyPart.LEFT_EYE),
+                (from: BodyPart.LEFT_EYE, to: BodyPart.LEFT_EAR),
+                (from: BodyPart.RIGHT_SHOULDER, to: BodyPart.RIGHT_EAR),
+                (from: BodyPart.LEFT_SHOULDER, to: BodyPart.LEFT_EAR),
+            ]
+        }
+    }
+}
+
+private extension PoseEstimationOutput {
+    init(outputs: [TFLiteFlatArray<Float32>]) {
+        let keypoints = convertToKeypoints(from: outputs)
+        let lines = makeLines(with: keypoints)
+        
+        self.keypoints = keypoints
+        self.lines = lines
+    }
+    
+    func convertToKeypoints(from outputs: [TFLiteFlatArray<Float32>]) -> [Keypoint] {
+        let output = outputs[0]
+        
+        // get (col, row)s from heatmaps
+        let keypointIndexInfos: [(row: Int, col: Int, val: Float32)] = (0..<OpenPosePoseEstimator.Output.ConfidenceMap.count).map { heatmapIndex in
+            var maxInfo = (row: 0, col: 0, val: output[heatmap: 0, 0, 0, heatmapIndex])
+            for row in 0..<OpenPosePoseEstimator.Output.ConfidenceMap.height {
+                for col in 0..<OpenPosePoseEstimator.Output.ConfidenceMap.width {
+                    if output[heatmap: 0, row, col, heatmapIndex] > maxInfo.val {
+                        maxInfo = (row: row, col: col, val: output[0, row, col, heatmapIndex])
+                    }
+                }
+            }
+            return maxInfo
+        }
+        
+        // get points from (col, row)s and offsets
+        let keypointInfos: [(point: CGPoint, score: CGFloat)] = keypointIndexInfos.enumerated().map { (index, keypointInfo) in
+            return (point: .zero, score: 0)
+        }
+        
+        return keypointInfos.map { keypointInfo in Keypoint(position: keypointInfo.point, score: keypointInfo.score) }
+    }
+    
+    func makeLines(with keypoints: [Keypoint]) -> [Line] {
+        var keypointWithBodyPart: [OpenPosePoseEstimator.Output.BodyPart: Keypoint] = [:]
+        OpenPosePoseEstimator.Output.BodyPart.allCases.enumerated().forEach { (index, bodyPart) in
+            keypointWithBodyPart[bodyPart] = keypoints[index]
+        }
+        return OpenPosePoseEstimator.Output.BodyPart.lines.compactMap { line in
+            guard let fromKeypoint = keypointWithBodyPart[line.from],
+                let toKeypoint = keypointWithBodyPart[line.to] else { return nil }
+            return (from: fromKeypoint, to: toKeypoint)
+        }
+    }
+}
+
+extension TFLiteFlatArray where Element == Float32 {
+    subscript(heatmap heatmap: Int...) -> Element {
+        get { return self.element(at: heatmap) }
+    }
+    subscript(paf paf: Int...) -> Element {
+        get {
+            var indexes = paf
+            indexes[indexes.count-1] = indexes[indexes.count-1] + OpenPosePoseEstimator.Output.ConfidenceMap.count
+            return self.element(at: indexes)
+        }
+    }
+}

--- a/PoseEstimation-TFLiteSwift/TFLiteFlatArray.swift
+++ b/PoseEstimation-TFLiteSwift/TFLiteFlatArray.swift
@@ -34,12 +34,16 @@ struct TFLiteFlatArray<Element: AdditiveArithmetic> {
         return result
     }
     
-    subscript(_ index: Int...) -> Element {
+    func element(at indexes: [Int]) -> Element {
+        return array[flatIndex(indexes)]
+    }
+    
+    subscript(indexes: Int...) -> Element {
         get {
-            return array[flatIndex(index)]
+            return array[flatIndex(indexes)]
         }
         set(newValue) {
-            array[flatIndex(index)] = newValue
+            array[flatIndex(indexes)] = newValue
         }
     }
 }

--- a/PoseEstimation-TFLiteSwift/TFLiteImageInterpreter.swift
+++ b/PoseEstimation-TFLiteSwift/TFLiteImageInterpreter.swift
@@ -63,7 +63,7 @@ class TFLiteImageInterpreter {
             inputTensor.shape.dimensions[2] == options.inputWidth,
             inputTensor.shape.dimensions[3] == options.inputChannel
         else {
-            fatalError("Unexpected Model: input shape")
+            fatalError("Unexpected Model: input shape \n\(inputTensor.shape) != [\(1), \(options.inputHeight), \(options.inputWidth), \(options.inputChannel)]")
         }
         self.inputTensor = inputTensor
         

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ pod install
 ## See also
 
 - [motlabs/awesome-ml-demos-with-ios](https://github.com/motlabs/awesome-ml-demos-with-ios)
-- [tucan9389/PoseEstimation-CoreML](https://github.com/tucan9389/PoseEstimation-CoreML)
-- [PoseNet example of tensorflow/examples](https://github.com/tensorflow/examples/blob/master/lite/examples/posenet/ios)
-- [edvardHua/PoseEstimationForMobile](https://github.com/edvardHua/PoseEstimationForMobile)
-- [osmr/imgclsmob](https://github.com/osmr/imgclsmob)
+- Pose estimation with Core ML - [tucan9389/PoseEstimation-CoreML](https://github.com/tucan9389/PoseEstimation-CoreML)
+- TFLite model provided by:
+  - CPM and Hourglass model provided by  [edvardHua/PoseEstimationForMobile](https://github.com/edvardHua/PoseEstimationForMobile)
+  - PoseNet model provided by [tensorflow/examples](https://github.com/tensorflow/examples/blob/master/lite/examples/posenet/ios)
+  - OpenPose model provided by [ildoonet/tf-pose-estimation](https://github.com/ildoonet/tf-pose-estimation)
+  - Various model provided by [osmr/imgclsmob](https://github.com/osmr/imgclsmob)


### PR DESCRIPTION
## PR Points

- Support OpenPose tflite model provided by [ildoonet/tf-pose-estimation](https://github.com/ildoonet/tf-pose-estimation)

## Caution

`ildoonet/tf-pose-estimation` pose model supports multi-person pose estimation using PCM(Part Confidence Maps) and PAF(Part Affinity Fields). In this PR, I only used PCM and support only single person pose estimation. I'll support multi-person pose estimation as soon as possible.

## Ref

https://arxiv.org/abs/1812.08008
```
@article{DBLP:journals/corr/abs-1812-08008,
  author    = {Zhe Cao and
               Gines Hidalgo and
               Tomas Simon and
               Shih{-}En Wei and
               Yaser Sheikh},
  title     = {OpenPose: Realtime Multi-Person 2D Pose Estimation using Part Affinity
               Fields},
  journal   = {CoRR},
  volume    = {abs/1812.08008},
  year      = {2018},
  url       = {http://arxiv.org/abs/1812.08008},
  archivePrefix = {arXiv},
  eprint    = {1812.08008},
  timestamp = {Wed, 02 Jan 2019 14:40:18 +0100},
  biburl    = {https://dblp.org/rec/journals/corr/abs-1812-08008.bib},
  bibsource = {dblp computer science bibliography, https://dblp.org}
}
```