### PR TITLE
[PR] Add shoulder fixing function for 3d pose keypoints and lines

### DIFF
--- a/PoseEstimation-TFLiteSwift/Base.lproj/Main.storyboard
+++ b/PoseEstimation-TFLiteSwift/Base.lproj/Main.storyboard
@@ -2200,11 +2200,27 @@
                             <sceneKitView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jkq-Rb-Jrj" customClass="Pose3DSceneView" customModule="Pose_TFLiteSwift" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="346" width="414" height="467"/>
                             </sceneKitView>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="WJ1-Lq-ZKz">
+                                <rect key="frame" x="361" y="350" width="51" height="31"/>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shoulder Fixing:" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ork-gb-ut7">
+                                <rect key="frame" x="287" y="350" width="70" height="31.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="70" id="sEB-jf-fNC"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="laA-uJ-4KK"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="WJ1-Lq-ZKz" firstAttribute="leading" secondItem="Ork-gb-ut7" secondAttribute="trailing" constant="4" id="2p2-yU-FiF"/>
+                            <constraint firstItem="WJ1-Lq-ZKz" firstAttribute="top" secondItem="Jkq-Rb-Jrj" secondAttribute="top" constant="4" id="FwW-Fh-bnp"/>
+                            <constraint firstItem="Ork-gb-ut7" firstAttribute="centerY" secondItem="WJ1-Lq-ZKz" secondAttribute="centerY" id="I9d-MN-rZq"/>
                             <constraint firstItem="Jkq-Rb-Jrj" firstAttribute="top" secondItem="C22-RT-EhJ" secondAttribute="bottom" id="LTv-4U-nxw"/>
+                            <constraint firstItem="WJ1-Lq-ZKz" firstAttribute="trailing" secondItem="Jkq-Rb-Jrj" secondAttribute="trailing" constant="-4" id="Oal-dV-57z"/>
                             <constraint firstItem="laA-uJ-4KK" firstAttribute="bottom" secondItem="Jkq-Rb-Jrj" secondAttribute="bottom" id="R4z-Hl-8zQ"/>
                             <constraint firstItem="Jkq-Rb-Jrj" firstAttribute="leading" secondItem="laA-uJ-4KK" secondAttribute="leading" id="Tk9-iH-9q6"/>
                             <constraint firstItem="C22-RT-EhJ" firstAttribute="centerX" secondItem="BA4-2C-qdi" secondAttribute="centerX" id="Waa-De-7YN"/>
@@ -2217,6 +2233,7 @@
                     <connections>
                         <outlet property="outputRenderingView" destination="Jkq-Rb-Jrj" id="Q13-b8-X6d"/>
                         <outlet property="previewView" destination="C22-RT-EhJ" id="2hG-tK-A65"/>
+                        <outlet property="shoulderFixingSwitch" destination="WJ1-Lq-ZKz" id="RGL-kg-0mz"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sUi-Mc-DkZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -2291,6 +2308,18 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="pld-5c-MBa">
+                                <rect key="frame" x="313.5" y="415" width="51" height="31"/>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shoulder Fixing:" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pmM-ul-iuW">
+                                <rect key="frame" x="239.5" y="415" width="70" height="31.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="70" id="9S4-6k-hYG"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="FdQ-H1-SQH"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -2304,9 +2333,12 @@
                             <constraint firstItem="Mfb-8N-vbW" firstAttribute="top" secondItem="FdQ-H1-SQH" secondAttribute="top" id="EIH-je-mL6"/>
                             <constraint firstItem="xRB-hD-k7k" firstAttribute="centerX" secondItem="T81-gz-JI3" secondAttribute="centerX" id="ErK-9P-eoF"/>
                             <constraint firstItem="Zc6-eO-N8l" firstAttribute="top" secondItem="T9P-CY-CYq" secondAttribute="top" id="Fbp-hX-9dj"/>
+                            <constraint firstItem="pld-5c-MBa" firstAttribute="leading" secondItem="pmM-ul-iuW" secondAttribute="trailing" constant="4" id="GkK-GC-iv0"/>
                             <constraint firstItem="WgN-ye-lJb" firstAttribute="centerX" secondItem="T81-gz-JI3" secondAttribute="centerX" id="Hpw-af-YSl"/>
                             <constraint firstItem="xTf-hF-75a" firstAttribute="top" secondItem="Zc6-eO-N8l" secondAttribute="top" id="Inb-aT-9Zd"/>
+                            <constraint firstItem="pmM-ul-iuW" firstAttribute="centerY" secondItem="pld-5c-MBa" secondAttribute="centerY" id="LII-lM-QJJ"/>
                             <constraint firstItem="T9P-CY-CYq" firstAttribute="height" secondItem="xRB-hD-k7k" secondAttribute="height" multiplier="1:1" id="Nn3-Xr-7ei"/>
+                            <constraint firstItem="pld-5c-MBa" firstAttribute="top" secondItem="xRB-hD-k7k" secondAttribute="top" constant="4" id="OEQ-d6-I54"/>
                             <constraint firstItem="xTf-hF-75a" firstAttribute="centerX" secondItem="Zc6-eO-N8l" secondAttribute="centerX" id="OLQ-lm-ST8"/>
                             <constraint firstItem="FdQ-H1-SQH" firstAttribute="bottom" secondItem="T9P-CY-CYq" secondAttribute="bottom" id="OUN-K1-IfJ"/>
                             <constraint firstItem="vuE-YC-bgN" firstAttribute="top" secondItem="T9P-CY-CYq" secondAttribute="top" id="Py6-Z6-iAE"/>
@@ -2320,6 +2352,7 @@
                             <constraint firstItem="T9P-CY-CYq" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="FdQ-H1-SQH" secondAttribute="leading" constant="6" id="jVL-mQ-jZT"/>
                             <constraint firstItem="xRB-hD-k7k" firstAttribute="top" secondItem="WgN-ye-lJb" secondAttribute="bottom" id="le8-rQ-lJB"/>
                             <constraint firstItem="WgN-ye-lJb" firstAttribute="top" secondItem="Mfb-8N-vbW" secondAttribute="bottom" id="n8y-k3-KlW"/>
+                            <constraint firstItem="pld-5c-MBa" firstAttribute="trailing" secondItem="xRB-hD-k7k" secondAttribute="trailing" constant="-4" id="oJs-uw-FOb"/>
                             <constraint firstItem="Zc6-eO-N8l" firstAttribute="leading" secondItem="T9P-CY-CYq" secondAttribute="trailing" id="oz4-Gk-zes"/>
                             <constraint firstItem="vuE-YC-bgN" firstAttribute="leading" secondItem="T9P-CY-CYq" secondAttribute="leading" id="yD6-1Y-flR"/>
                         </constraints>
@@ -2342,6 +2375,7 @@
                         <outlet property="listeningButtonItem" destination="z0A-n4-2Wg" id="ezO-7m-bb6"/>
                         <outlet property="outputRenderingView" destination="xRB-hD-k7k" id="29B-Kt-UvV"/>
                         <outlet property="previewView" destination="WgN-ye-lJb" id="e75-WS-hcv"/>
+                        <outlet property="shoulderFixingSwitch" destination="pld-5c-MBa" id="k4Q-mv-k1L"/>
                         <outlet property="speechStatusLabel" destination="Mfb-8N-vbW" id="Gtv-LB-fCT"/>
                         <outletCollection property="capturedRenderingViews" destination="T9P-CY-CYq" collectionClass="NSMutableArray" id="doO-KO-ixd"/>
                         <outletCollection property="capturedRenderingViews" destination="Zc6-eO-N8l" collectionClass="NSMutableArray" id="PoA-RD-bA0"/>

--- a/PoseEstimation-TFLiteSwift/Baseline3DPose/Baseline3DPoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/Baseline3DPose/Baseline3DPoseEstimator.swift
@@ -115,6 +115,8 @@ private extension Baseline3DPoseEstimator {
             case RIGHT_WRIST = "R_Wrist"        // 16
             case THORAX = "Thorax"              // 17
 
+            static let baselineKeypointIndexes = (11, 14)  // L_Shoulder, R_Shoulder
+            
             static let lines = [
                 (from: BodyPart.PELVIS, to: BodyPart.TORSO),
                 (from: BodyPart.TORSO, to: BodyPart.NECK),
@@ -144,7 +146,7 @@ private extension PoseEstimationOutput {
         let keypoints = convertToKeypoints(from: outputs)
         let lines = makeLines(with: keypoints)
         
-        humans = [.human3d(human: Human3D(keypoints: keypoints, lines: lines))]
+        humans = [.human3d(human: Human3D(keypoints: keypoints, lines: lines, baselineKeypointIndexes: Baseline3DPoseEstimator.Output.BodyPart.baselineKeypointIndexes))]
     }
     
     func convertToKeypoints(from outputs: [TFLiteFlatArray<Float32>]) -> [Keypoint3D] {

--- a/PoseEstimation-TFLiteSwift/LiteBaseline3DPose/LiteBaseline3DPoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/LiteBaseline3DPose/LiteBaseline3DPoseEstimator.swift
@@ -123,6 +123,8 @@ private extension LiteBaseline3DPoseEstimator {
             case RIGHT_ELBOW = "R_Elbow"        // 15
             case RIGHT_WRIST = "R_Wrist"        // 16
             case THORAX = "Thorax"              // 17
+            
+            static let baselineKeypointIndexes = (11, 14)  // L_Shoulder, R_Shoulder
 
             static let lines = [
                 (from: BodyPart.PELVIS, to: BodyPart.TORSO),
@@ -153,7 +155,7 @@ private extension PoseEstimationOutput {
         let keypoints = convertToKeypoints(from: outputs)
         let lines = makeLines(with: keypoints)
         
-        humans = [.human3d(human: Human3D(keypoints: keypoints, lines: lines))]
+        humans = [.human3d(human: Human3D(keypoints: keypoints, lines: lines, baselineKeypointIndexes: LiteBaseline3DPoseEstimator.Output.BodyPart.baselineKeypointIndexes))]
     }
     
     func convertToKeypoints(from outputs: [TFLiteFlatArray<Float32>]) -> [Keypoint3D] {

--- a/PoseEstimation-TFLiteSwift/Live3DRenderingAndCapturingViewController.swift
+++ b/PoseEstimation-TFLiteSwift/Live3DRenderingAndCapturingViewController.swift
@@ -14,6 +14,7 @@ class Live3DRenderingAndCapturingViewController: UIViewController {
     
     // MARK: - IBOutlets
     @IBOutlet weak var speechStatusLabel: UILabel?
+    @IBOutlet weak var shoulderFixingSwitch: UISwitch?
     @IBOutlet weak var previewView: UIView?
     @IBOutlet weak var outputRenderingView: Pose3DSceneView?
     @IBOutlet var capturedRenderingViews: [Pose3DSceneView]?
@@ -44,8 +45,13 @@ class Live3DRenderingAndCapturingViewController: UIViewController {
     var outputHuman: PoseEstimationOutput.Human3D? {
         didSet {
             DispatchQueue.main.async {
-                self.outputRenderingView?.keypoints = self.outputHuman?.keypoints ?? []
-                self.outputRenderingView?.lines = self.outputHuman?.lines ?? []
+                if self.shoulderFixingSwitch?.isOn == true {
+                    self.outputRenderingView?.keypoints = self.outputHuman?.adjustKeypoints() ?? []
+                    self.outputRenderingView?.lines = self.outputHuman?.adjustLines() ?? []
+                } else {
+                    self.outputRenderingView?.keypoints = self.outputHuman?.keypoints ?? []
+                    self.outputRenderingView?.lines = self.outputHuman?.lines ?? []
+                }
             }
         }
     }
@@ -185,8 +191,13 @@ class Live3DRenderingAndCapturingViewController: UIViewController {
             capturedOutputHumans.removeLast()
         }
         for (capturedOutputHuman, capturedRenderingView) in zip(capturedOutputHumans, capturedRenderingViews) {
-            capturedRenderingView.keypoints = capturedOutputHuman.keypoints
-            capturedRenderingView.lines = capturedOutputHuman.lines
+            if self.shoulderFixingSwitch?.isOn == true {
+                capturedRenderingView.keypoints = capturedOutputHuman.adjustKeypoints()
+                capturedRenderingView.lines = capturedOutputHuman.adjustLines()
+            } else {
+                capturedRenderingView.keypoints = capturedOutputHuman.keypoints
+                capturedRenderingView.lines = capturedOutputHuman.lines
+            }
         }
         capturedHumanResults.insert(capturedHuman, at: 0)
         while capturedHumanResults.count > capturedRenderingViews.count {
@@ -412,52 +423,56 @@ private extension Array where Element == PoseEstimationOutput.Human3D.Line3D {
     
 }
 
-private extension PoseEstimationOutput.Human3D {
+extension PoseEstimationOutput.Human3D {
     func adjustLines() -> [PoseEstimationOutput.Human3D.Line3D] {
-        guard let baselineKeypointIndexes = baselineKeypointIndexes else { return [] }
-        let index1 = baselineKeypointIndexes.0
-        let index2 = baselineKeypointIndexes.1
+        guard let index1 = baselineKeypointIndexes?.0, let index2 = baselineKeypointIndexes?.1 else { return [] }
         guard let kp1 = keypoints[index1], let kp2 = keypoints[index2] else { return [] }
         
         let kp1_f = kp1.position.simdVector
         let kp2_f = kp2.position.simdVector
         let kp_m_f = (kp1_f + kp2_f) / 2.0
         
-        let moved_kp1_f = kp1_f - kp_m_f
-        let theta1: Float = atan(moved_kp1_f.y / moved_kp1_f.x) // radian
-        let roated_kp1_f = moved_kp1_f.rotate(angle: -theta1, axis: .zAxis)
-        let theta2: Float = atan(roated_kp1_f.z / roated_kp1_f.x) // radian
+        let (theta1, theta2) = getThetas(kp_f: kp1_f, kp_m_f: kp_m_f)
         
         return lines.map { line -> (from: Keypoint3D, to: Keypoint3D) in
-            let to = ((line.to.position.simdVector - kp_m_f).rotate(angle: -theta1, axis: .zAxis).rotate(angle: -theta2, axis: .yAxis) + kp_m_f).keypoint
-            let from = ((line.from.position.simdVector - kp_m_f).rotate(angle: -theta1, axis: .zAxis).rotate(angle: -theta2, axis: .yAxis) + kp_m_f).keypoint
+            let from = line.from.adjustKeypoint(theta1: theta1, theta2: theta2, kp_m_f: kp_m_f)
+            let to = line.to.adjustKeypoint(theta1: theta1, theta2: theta2, kp_m_f: kp_m_f)
             return (from: from, to: to)
         }
     }
     
     func adjustKeypoints() -> [Keypoint3D?] {
-        guard let baselineKeypointIndexes = baselineKeypointIndexes else { return [] }
-        let index1 = baselineKeypointIndexes.0
-        let index2 = baselineKeypointIndexes.1
+        guard let index1 = baselineKeypointIndexes?.0, let index2 = baselineKeypointIndexes?.1 else { return [] }
         guard let kp1 = keypoints[index1], let kp2 = keypoints[index2] else { return [] }
         
         let kp1_f = kp1.position.simdVector
         let kp2_f = kp2.position.simdVector
         let kp_m_f = (kp1_f + kp2_f) / 2.0
         
-        let moved_kp1_f = kp1_f - kp_m_f
-        let theta1: Float = atan(moved_kp1_f.y / moved_kp1_f.x) // radian
-        let roated_kp1_f = moved_kp1_f.rotate(angle: -theta1, axis: .zAxis)
-        let theta2: Float = atan(roated_kp1_f.z / roated_kp1_f.x) // radian
+        let (theta1, theta2) = getThetas(kp_f: kp1_f, kp_m_f: kp_m_f)
         
         return keypoints.map { keypoint in
-            guard let keypoint = keypoint else { return nil }
-            let kp_f = keypoint.position.simdVector
-            let moved_kp_f = kp_f - kp_m_f
-            let roated_kp_f = moved_kp_f.rotate(angle: -theta1, axis: .zAxis).rotate(angle: -theta2, axis: .yAxis)
-            let movebaced_kp_f = roated_kp_f + kp_m_f
-            return movebaced_kp_f.keypoint
+            return keypoint?.adjustKeypoint(theta1: theta1, theta2: theta2, kp_m_f: kp_m_f)
         }
+    }
+    
+    func getThetas(kp_f: simd_float3, kp_m_f: simd_float3) -> (theta1: Float, theta2: Float) {
+        let moved_kp_f = kp_f - kp_m_f
+        let theta1: Float = atan(moved_kp_f.y / moved_kp_f.x) // radian
+        let roated_kp_f = moved_kp_f.rotate(angle: -theta1, axis: .zAxis)
+        let theta2: Float = atan(roated_kp_f.z / roated_kp_f.x) // radian
+        return (theta1, theta2)
+    }
+}
+
+extension Keypoint3D {
+    func adjustKeypoint(theta1: Float, theta2: Float, kp_m_f: simd_float3) -> Keypoint3D {
+        let kp_f = position.simdVector
+        let moved_kp_f = kp_f - kp_m_f
+        let roated_kp_f = moved_kp_f.rotate(angle: -theta1, axis: .zAxis).rotate(angle: -theta2, axis: .yAxis)
+        let middlex_kp_m_f = simd_float3(x: 0.5, y: kp_m_f.y, z: kp_m_f.z)
+        let movebacked_kp_f = roated_kp_f + middlex_kp_m_f
+        return movebacked_kp_f.keypoint
     }
 }
 

--- a/PoseEstimation-TFLiteSwift/Live3DRenderingViewController.swift
+++ b/PoseEstimation-TFLiteSwift/Live3DRenderingViewController.swift
@@ -12,6 +12,7 @@ import CoreMedia
 class Live3DRenderingViewController: UIViewController {
 
     // MARK: - IBOutlets
+    @IBOutlet weak var shoulderFixingSwitch: UISwitch?
     @IBOutlet weak var previewView: UIView?
     @IBOutlet weak var outputRenderingView: Pose3DSceneView?
     
@@ -36,8 +37,13 @@ class Live3DRenderingViewController: UIViewController {
     var outputHuman: PoseEstimationOutput.Human3D? {
         didSet {
             DispatchQueue.main.async {
-                self.outputRenderingView?.keypoints = self.outputHuman?.keypoints ?? []
-                self.outputRenderingView?.lines = self.outputHuman?.lines ?? []
+                if self.shoulderFixingSwitch?.isOn == true {
+                    self.outputRenderingView?.keypoints = self.outputHuman?.adjustKeypoints() ?? []
+                    self.outputRenderingView?.lines = self.outputHuman?.adjustLines() ?? []
+                } else {
+                    self.outputRenderingView?.keypoints = self.outputHuman?.keypoints ?? []
+                    self.outputRenderingView?.lines = self.outputHuman?.lines ?? []
+                }
             }
         }
     }

--- a/PoseEstimation-TFLiteSwift/PoseEstimator.swift
+++ b/PoseEstimation-TFLiteSwift/PoseEstimator.swift
@@ -24,6 +24,7 @@
 
 import CoreVideo
 import UIKit
+import simd
 
 struct PreprocessOptions {
     let cropArea: CropArea
@@ -143,6 +144,10 @@ struct Keypoint3D {
         let x: CGFloat
         let y: CGFloat
         let z: CGFloat
+        
+        var simdVector: simd_float3 {
+            return simd_float3(x: Float(x), y: Float(y), z: Float(z))
+        }
     }
     
     let position: Point3D
@@ -202,6 +207,7 @@ struct PoseEstimationOutput {
         typealias Line3D = (from: Keypoint3D, to: Keypoint3D)
         var keypoints: [Keypoint3D?] = []
         var lines: [Line3D] = []
+        var baselineKeypointIndexes: (Int, Int)? = nil
     }
     
     enum Human {
@@ -236,4 +242,10 @@ protocol PoseEstimator {
     func postprocessOnLastOutput(options: PostprocessOptions) -> PoseEstimationOutput?
     var partNames: [String] { get }
     var pairNames: [String]? { get }
+}
+
+extension simd_float3 {
+    var keypoint: Keypoint3D {
+        return Keypoint3D(x: CGFloat(x), y: CGFloat(y), z: CGFloat(z))
+    }
 }


### PR DESCRIPTION
## PR Point

- Implement shoulder fixing function for 3d pose keypoints
    - Implement to rotate 3d vector by x-axis, y-axis, z-axis
    - Implement custom operator for multiplying or moving 3d vector 
    - Use the shoulder fixing before performing pose-matching algorithm
- Add a shoulder fixing switch for each 3d live demo page

## Vector Rotation

In 3D rotating around the Z-axis would be

```
    |cos θ   −sin θ   0| |x|   |x cos θ − y sin θ|   |x'|
    |sin θ    cos θ   0| |y| = |x sin θ + y cos θ| = |y'|
    |  0       0      1| |z|   |        z        |   |z'|
```

around the Y-axis would be

```
    | cos θ    0  -sin θ| |x|   | x cos θ + z sin θ|   |x'|
    |   0      1       0| |y| = |         y        | = |y'|
    |sin θ    0    cos θ| |z|   |−x sin θ + z cos θ|   |z'|
```

around the X-axis would be

```
    |1     0           0| |x|   |        x        |   |x'|
    |0   cos θ    −sin θ| |y| = |y cos θ − z sin θ| = |y'|
    |0   sin θ     cos θ| |z|   |y sin θ + z cos θ|   |z'|
```

## Reference

- https://developer.apple.com/documentation/accelerate/working_with_matrices
- https://stackoverflow.com/a/14609567/4160632